### PR TITLE
useframev2

### DIFF
--- a/src/I2sAnalyzer.cpp
+++ b/src/I2sAnalyzer.cpp
@@ -5,6 +5,7 @@
 I2sAnalyzer::I2sAnalyzer() : Analyzer2(), mSettings( new I2sAnalyzerSettings() ), mSimulationInitilized( false )
 {
     SetAnalyzerSettings( mSettings.get() );
+    UseFrameV2();
 }
 
 I2sAnalyzer::~I2sAnalyzer()


### PR DESCRIPTION
This won't build until the new UseFrameV2(); Function has become an official part of the SDK. In the meantime, do not use `UseFrameV2();`, as it will fail to build.